### PR TITLE
feat: add responsive gladiator theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,16 +15,14 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <!-- Load classical looking font for gladiator theme -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>Sculptor</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,27 +1,30 @@
+/* Gladiator inspired color palette */
 :root {
-  --white: #f5f5f5;
-  --green: #4caf50;
-  --yellow: #d4a017;
-  --orange: #e67e22;
-  --red: #c0392b;
-  --purple: #8e44ad;
-  --blue: #2980b9;
+  --white: #f4f1de; /* marble */
+  --green: #c9a14d; /* gold */
+  --yellow: #b87333; /* bronze */
+  --orange: #d2691e; /* copper */
+  --red: #7d0000; /* crimson */
+  --purple: #5e42a6; /* royal purple */
+  --blue: #1f3c88; /* deep navy */
 }
 
 body {
-  font-family: Arial, sans-serif;
-  background-color: #000;
+  font-family: 'Cinzel', serif;
+  background-color: #1a1a1a;
+  color: var(--white);
   padding: 40px 0;
-  /* background-image: url('/img/dark-gym-background-desktop.webp'); */
+  background-image: linear-gradient(rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.85)),
+    url('/img/dark-gym-background-desktop.webp');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  height: 100vh;
+  min-height: 100vh;
   text-transform: capitalize;
 }
 
 .app-title {
-  color: var(--white);
+  color: var(--green);
   text-align: center;
 }
 
@@ -54,6 +57,16 @@ body {
 .sculptor__button-add-exercise {
   position: absolute;
   right: 0;
+  background-color: var(--green);
+  color: var(--white);
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+}
+
+.sculptor__button-add-exercise:hover {
+  background-color: var(--yellow);
+  color: black;
 }
 
 [class^="sculptor__excercise-muscle"] {
@@ -197,4 +210,53 @@ body {
   border: none;
   font-size: 1.2rem;
   cursor: pointer;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  body {
+    padding: 20px 0;
+  }
+
+  .nav-tabs {
+    margin-top: 20px;
+  }
+
+  .nav-tabs .nav-link {
+    font-size: 16px;
+  }
+
+  .sculptor__workout {
+    padding: 20px 0;
+  }
+
+  .sculptor__workout-title {
+    font-size: 20px;
+    margin-bottom: 20px;
+  }
+}
+
+@media (max-width: 576px) {
+  .nav-tabs {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .nav-tabs .nav-link {
+    font-size: 14px;
+  }
+
+  .sculptor__button-add-exercise {
+    position: static;
+    margin-left: auto;
+  }
+
+  .sculptor__workout-button {
+    font-size: 16px;
+    margin-top: 60px;
+  }
+
+  .sculptor__excercise-row span {
+    min-width: 80px;
+  }
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders loading message initially', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const loadingElement = screen.getByText(/loading/i);
+  expect(loadingElement).toBeInTheDocument();
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,6 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Cinzel', serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## Summary
- theme app with gladiator-inspired palette and Cinzel font
- style add-exercise button and body for classical look
- add responsive breakpoints for mobile and tablet
- fix failing test to expect loading text

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68913a794c308328b61212c166fac31e